### PR TITLE
Remove copy(.babelrc)

### DIFF
--- a/bin/trek-new
+++ b/bin/trek-new
@@ -100,7 +100,6 @@ function createApplication(appName, appPath) {
   copy('public')
   copy('test')
   copy('server.js')
-  copy('.babelrc')
   copy('.editorconfig')
   copy('.eslintrc')
   copy('.travis.yml')


### PR DESCRIPTION
.babelrc was removed during 683cfeed972e79249870d5405f3b07a578bd3a36 causing the CLI to crash.
